### PR TITLE
Enable the ability to pass build args and env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM r.j3ss.co/img
 USER root
 ENV USER root
 ENV HOME /root
-RUN apk add bash rsync
+RUN apk add bash rsync jq
 ADD build /usr/bin/build

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The following are optional:
 * `$DOCKERFILE` (default `$CONTEXT/Dockerfile`): the path to the `Dockerfile`
   to build.
 
+* `$BUILD_ARGS` (default empty): Map of build args
+
+* `$ENV` (default empty): Map of environment variables that will be passed in to the image build
+
 ### `inputs`
 
 There are no required inputs - your task should just list each artifact it

--- a/build
+++ b/build
@@ -66,6 +66,19 @@ function progress() {
 TAG=${TAG:-latest}
 CONTEXT=${CONTEXT:-.}
 DOCKERFILE=${DOCKERFILE:-$CONTEXT/Dockerfile}
+if [[ -n "$BUILD_ARGS" ]]
+then
+  BUILD_ARGS_OPT=$(echo $BUILD_ARGS | jq -j -r 'to_entries[] | "--build-args " + .key + "=\"" + (.value|tostring) + "\" "')
+else
+  BUILD_ARGS_OPT=""
+fi
+
+if [[ -n "$ENV" ]]
+then
+  ENV_OPT=$(echo $ENV | jq -j -r 'to_entries[] | "--env " + .key + "=\"" + (.value|tostring) + "\" "')
+else
+  ENV_OPT=""
+fi
 
 if [ -d ./cache/state ]; then
   progress "syncing cache to state"
@@ -80,7 +93,7 @@ if [ -e ./cache/whiteouts ]; then
 fi
 
 progress "building"
-img build -s /scratch/state -t $REPOSITORY:$TAG -f $DOCKERFILE $CONTEXT
+img build -s /scratch/state -t $REPOSITORY:$TAG -f $DOCKERFILE $BUILD_ARGS_OPT $ENV_OPT $CONTEXT
 
 if [ -d ./cache ]; then
   progress "syncing state to cache"


### PR DESCRIPTION
This commit adds the ability to pass build args and environment variables to
`img` build command.

It should resolve issue #3 