### PR TITLE
Ability to pass build args from params

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The following are optional:
 * `$DOCKERFILE` (default `$CONTEXT/Dockerfile`): the path to the `Dockerfile`
   to build.
 
+* `$BUILD_ARG_*` (default empty): Params that start with `BUILD_ARG_` will be
+  translated to `--build-arg` options. For example `BUILD_ARG_foo=bar`, will become
+  `--build-arg foo=bar`
+
 ### `inputs`
 
 There are no required inputs - your task should just list each artifact it

--- a/build
+++ b/build
@@ -66,6 +66,7 @@ function progress() {
 TAG=${TAG:-latest}
 CONTEXT=${CONTEXT:-.}
 DOCKERFILE=${DOCKERFILE:-$CONTEXT/Dockerfile}
+BUILD_ARGS_OPT=$(env | awk '/BUILD_ARG_/ {gsub(/BUILD_ARG_/, "--build-arg "); printf "%s ",$0}')
 
 if [ -d ./cache/state ]; then
   progress "syncing cache to state"
@@ -80,7 +81,7 @@ if [ -e ./cache/whiteouts ]; then
 fi
 
 progress "building"
-img build -s /scratch/state -t $REPOSITORY:$TAG -f $DOCKERFILE $CONTEXT
+img build -s /scratch/state -t $REPOSITORY:$TAG -f $DOCKERFILE $BUILD_ARGS_OPT $CONTEXT
 
 if [ -d ./cache ]; then
   progress "syncing state to cache"


### PR DESCRIPTION
Params that start with `BUILD_ARG_` will be translated to `--build-arg` options.

It should resolve issue #3

Signed-off-by: Yasser Saleemi <yassersaleemi@gmail.com>