### PR TITLE
Add `TARGET` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ The following are optional:
   image tarball. This can be used to start the image in a subsequent task without
   uploading it to a registry using the ["image:" task step option](https://concourse-ci.org/task-step.html#task-step-image).
 
-* `$TARGET` (default empty): Set the target build stage to build.
+* `$TARGET` (default empty): the target build stage to build.
+
+* `$TARGET_FILE` (default empty): the path to a file containing the name of the target build stage to build.
 
 ### `inputs`
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following are optional:
   image tarball. This can be used to start the image in a subsequent task without
   uploading it to a registry using the ["image:" task step option](https://concourse-ci.org/task-step.html#task-step-image).
 
+* `$TARGET` (default empty): Set the target build stage to build.
 
 ### `inputs`
 

--- a/build
+++ b/build
@@ -67,6 +67,7 @@ TAG=${TAG:-latest}
 TAG_FILE=${TAG_FILE:-}
 CONTEXT=${CONTEXT:-.}
 DOCKERFILE=${DOCKERFILE:-$CONTEXT/Dockerfile}
+TARGET_OPT=$([[ ! -z "$TARGET" ]] && echo "--target $TARGET" || echo "")
 BUILD_ARGS_OPT=$(env | awk '/BUILD_ARG_/ {gsub(/BUILD_ARG_/, "--build-arg "); printf "%s ",$0}')
 BUILD_ARGS_FILE=${BUILD_ARGS_FILE:-}
 
@@ -113,7 +114,7 @@ if [ -e ./cache/whiteouts ]; then
 fi
 
 progress "building"
-img build -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $build_args $CONTEXT
+img build -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $TARGET_OPT $build_args $CONTEXT
 
 if [ -d ./cache ]; then
   progress "syncing state to cache"

--- a/build
+++ b/build
@@ -67,9 +67,11 @@ TAG=${TAG:-latest}
 TAG_FILE=${TAG_FILE:-}
 CONTEXT=${CONTEXT:-.}
 DOCKERFILE=${DOCKERFILE:-$CONTEXT/Dockerfile}
-TARGET_OPT=$([[ ! -z "$TARGET" ]] && echo "--target $TARGET" || echo "")
+TARGET=${TARGET:-}
+TARGET_FILE=${TARGET_FILE:-}
 BUILD_ARGS_OPT=$(env | awk '/BUILD_ARG_/ {gsub(/BUILD_ARG_/, "--build-arg "); printf "%s ",$0}')
 BUILD_ARGS_FILE=${BUILD_ARGS_FILE:-}
+
 
 tag_name=""
 if [ -n "$TAG_FILE" ]; then
@@ -81,6 +83,19 @@ if [ -n "$TAG_FILE" ]; then
 else
   tag_name="$TAG"
 fi
+
+
+target_arg=""
+if [ -n "$TARGET_FILE" ]; then
+  if [ ! -f "$TARGET_FILE" ]; then
+    echo "target file '$TARGET_FILE' does not exist"
+    exit 1
+  fi
+  target_arg="--target $(cat $TARGET_FILE)"
+elif [ -n "$TARGET" ]; then
+  target_arg="--target $TARGET"
+fi
+
 
 build_args=""
 if [ -n "$BUILD_ARGS_FILE" ]; then
@@ -114,7 +129,7 @@ if [ -e ./cache/whiteouts ]; then
 fi
 
 progress "building"
-img build -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $TARGET_OPT $build_args $CONTEXT
+img build -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $target_arg $build_args $CONTEXT
 
 if [ -d ./cache ]; then
   progress "syncing state to cache"


### PR DESCRIPTION
Previously, there was no way of having a particular stage
targetted when using the `build` script.

Being able to do so is particularly important for cases when
the default final stage does not need an intermediary testing
stage, meaning that such stage doesn't even get executed.

Now, with `--target`, one is able to have a task that explicitly
targets testing, leaving another task doing the default (or reaching
a `release` target).

For example:

```Dockerfile
FROM alpine AS build

	RUN echo "build" > /build

FROM alpine AS test

	RUN echo "test" > /test

FROM alpine AS release

	COPY --from=build /build /build
```

Without `--target`:

`build` and `release` are run.

With `--target=test`:

`test` is run.

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>