### PR TITLE
Add support for whitespace inside build args

### DIFF
--- a/build
+++ b/build
@@ -97,7 +97,7 @@ fi
 
 build_args=()
 
-while read -r line && test "${line}"; do
+while read -r line && test -n "${line}"; do
   build_args+=('--build-arg')
   build_args+=("${line}")
 done <<<"$(env | grep -E '^BUILD_ARG_' | sed -n 's/^BUILD_ARG_//p')"

--- a/build
+++ b/build
@@ -71,12 +71,6 @@ TARGET=${TARGET:-}
 TARGET_FILE=${TARGET_FILE:-}
 BUILD_ARGS_FILE=${BUILD_ARGS_FILE:-}
 
-BUILD_ARGS_OPT=()
-while read -r line && test "${line}"; do
-  BUILD_ARGS_OPT+=('--build-arg')
-  BUILD_ARGS_OPT+=("${line}")
-done <<<"$(env | grep -E '^BUILD_ARG_' | sed -n 's/^BUILD_ARG_//p')"
-
 tag_name=""
 if [ -n "$TAG_FILE" ]; then
   if [ ! -f "$TAG_FILE" ]; then
@@ -101,22 +95,24 @@ elif [ -n "$TARGET" ]; then
 fi
 
 
-build_args=""
+build_args=()
+
+while read -r line && test "${line}"; do
+  build_args+=('--build-arg')
+  build_args+=("${line}")
+done <<<"$(env | grep -E '^BUILD_ARG_' | sed -n 's/^BUILD_ARG_//p')"
+
 if [ -n "$BUILD_ARGS_FILE" ]; then
   if [ ! -f "$BUILD_ARGS_FILE" ]; then
     echo "build_args file '$BUILD_ARGS_FILE' does not exist"
     exit 1
   fi
 
-  expanded_build_args=()
   while IFS= read -r line || [ -n "$line" ];
   do
-    expanded_build_args+=("--build-arg")
-    expanded_build_args+=("${line}")
-  done < $BUILD_ARGS_FILE
-  build_args="${expanded_build_args[@]}"
-else
-  build_args="$BUILD_ARGS_OPT"
+    build_args+=("--build-arg")
+    build_args+=("${line}")
+  done < "$BUILD_ARGS_FILE"
 fi
 
 if [ -d ./cache/state ]; then
@@ -132,7 +128,7 @@ if [ -e ./cache/whiteouts ]; then
 fi
 
 progress "building"
-img build -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $target_arg $build_args $CONTEXT
+img build -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $target_arg "${build_args[@]}" $CONTEXT
 
 if [ -d ./cache ]; then
   progress "syncing state to cache"

--- a/build
+++ b/build
@@ -69,9 +69,13 @@ CONTEXT=${CONTEXT:-.}
 DOCKERFILE=${DOCKERFILE:-$CONTEXT/Dockerfile}
 TARGET=${TARGET:-}
 TARGET_FILE=${TARGET_FILE:-}
-BUILD_ARGS_OPT=$(env | awk '/BUILD_ARG_/ {gsub(/BUILD_ARG_/, "--build-arg "); printf "%s ",$0}')
 BUILD_ARGS_FILE=${BUILD_ARGS_FILE:-}
 
+BUILD_ARGS_OPT=()
+while read -r line; do
+  BUILD_ARGS_OPT+=('--build-arg')
+  BUILD_ARGS_OPT+=("${line}")
+done <<<"$(env | grep -E '^BUILD_ARG_' | sed -n 's/^BUILD_ARG_//p')"
 
 tag_name=""
 if [ -n "$TAG_FILE" ]; then
@@ -114,7 +118,6 @@ if [ -n "$BUILD_ARGS_FILE" ]; then
 else
   build_args="$BUILD_ARGS_OPT"
 fi
-
 
 if [ -d ./cache/state ]; then
   progress "syncing cache to state"

--- a/build
+++ b/build
@@ -72,7 +72,7 @@ TARGET_FILE=${TARGET_FILE:-}
 BUILD_ARGS_FILE=${BUILD_ARGS_FILE:-}
 
 BUILD_ARGS_OPT=()
-while read -r line; do
+while read -r line && test "${line}"; do
   BUILD_ARGS_OPT+=('--build-arg')
   BUILD_ARGS_OPT+=("${line}")
 done <<<"$(env | grep -E '^BUILD_ARG_' | sed -n 's/^BUILD_ARG_//p')"

--- a/build
+++ b/build
@@ -108,7 +108,7 @@ if [ -n "$BUILD_ARGS_FILE" ]; then
     exit 1
   fi
 
-  while IFS= read -r line || [ -n "$line" ];
+  while IFS= read -r line && test -n "${line}" || [ -n "$line" ];
   do
     build_args+=("--build-arg")
     build_args+=("${line}")


### PR DESCRIPTION
Utilise a bash array to expand the parameters correctly for the img command.

We've been facing an issue where if we have a build argument that contains whitespace, `img` will think the second word is the context.

```sh
$ build_args="--build-arg VAR=some var"
$ img build --no-console -t image:latest $build_args .
... 
failed to solve: failed to resolve dockerfile: error from sender: failed to resolve : lstat var: no such file or directory
```

Changing to a bash array allows us to do parameter expansion:

```sh
$ build_args=( '--build-arg' 'VAR=some var' )
$ img build --no-console -t image:latest "${build_args[@]}" .
# builds as expected with `VAR` set to `some var`
```