### PR TITLE
Add option to unpack rootfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM r.j3ss.co/img
 USER root
 ENV USER root
 ENV HOME /root
-RUN apk add bash rsync
+RUN apk add bash rsync jq
 ADD build /usr/bin/build

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ The following are optional:
   translated to `--build-arg` options. For example `BUILD_ARG_foo=bar`, will become
   `--build-arg foo=bar`
 
+* `$UNPACK_ROOTFS` (default empty): If set to a non-empty value a `metadata.json`
+  and `rootfs` folder will be created in the output directory in addition to the 
+  image tarball. This can be used to start the image in a subsequent task without
+  uploading it to a registry using the ["image:" task step option](https://concourse-ci.org/task-step.html#task-step-image).
+
 ### `inputs`
 
 There are no required inputs - your task should just list each artifact it

--- a/build
+++ b/build
@@ -103,3 +103,12 @@ fi
 
 progress "saving image"
 img save -s /scratch/state -o image/image.tar $REPOSITORY:$TAG
+
+if [ -n "$UNPACK_ROOTFS" ]; then
+  progress "unpacking rootfs"
+  imageConfig=$(tar -Oxf image/image.tar manifest.json | jq -r '.[0].Config')
+  tar -Oxf image/image.tar $imageConfig | jq '{"user":.config.User,"env":.config.Env}' > image/metadata.json
+  RUNC_PATH=$(echo /tmp/img-runc*) # Can be removed once this is fixed https://github.com/genuinetools/img/issues/233
+  PATH=$RUNC_PATH:$PATH img unpack -s /scratch/state -o /scratch/rootfs $REPOSITORY:$TAG
+  rsync -a /scratch/rootfs/ ./image/rootfs
+fi


### PR DESCRIPTION
This can be used to use the build image in a subsequent task without uploading it to a registry.

Fixes #24 