### PR TITLE
Add dedicated output for unpacking the rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ The following are optional:
   DO_THING=false
   ```
 
-* `$UNPACK_ROOTFS` (default empty): If set to a non-empty value a `metadata.json`
-  and `rootfs` folder will be created in the output directory in addition to the 
-  image tarball. This can be used to start the image in a subsequent task without
-  uploading it to a registry using the ["image:" task step option](https://concourse-ci.org/task-step.html#task-step-image).
-
 * `$TARGET` (default empty): the target build stage to build.
 
 * `$TARGET_FILE` (default empty): the path to a file containing the name of the target build stage to build.
@@ -74,6 +69,10 @@ Your task may configure an output called `image`. The saved image tarball will
 be written to `image.tar` within the output. This tarball can be passed along
 to `docker load`, or uploaded to a registry using the [Registry Image
 resource](https://github.com/concourse/registry-image-resource#out-push-an-image-up-to-the-registry-under-the-given-tags).
+
+Your task may configure an output called `rootfs`. A `metadata.json` and `rootfs` subfolder will
+be created in the output. This can be used to start the image in a subsequent task without
+uploading it to a registry using the ["image" task step option](https://concourse-ci.org/task-step.html#task-step-image).
 
 ### `caches`
 

--- a/build
+++ b/build
@@ -152,11 +152,12 @@ fi
 progress "saving image"
 img save -s /scratch/state -o image/image.tar $REPOSITORY:$tag_name
 
-if [ -n "${UNPACK_ROOTFS:-}" ]; then
+if [ -d ./rootfs ]; then
   progress "unpacking rootfs"
   imageConfig=$(tar -Oxf image/image.tar manifest.json | jq -r '.[0].Config')
-  tar -Oxf image/image.tar $imageConfig | jq '{"user":.config.User,"env":.config.Env}' > image/metadata.json
+  tar -Oxf image/image.tar $imageConfig | jq '{"user":.config.User,"env":.config.Env}' > ./rootfs/metadata.json
   RUNC_PATH=$(echo /tmp/img-runc*) # Can be removed once this is fixed https://github.com/genuinetools/img/issues/233
   PATH=$RUNC_PATH:$PATH img unpack -s /scratch/state -o /scratch/rootfs $REPOSITORY:$TAG
-  rsync -a /scratch/rootfs/ ./image/rootfs
+  # unpacking to a btrfs backed baggageclaim volume directly hangs, so we unpack to /scratch and copy
+  rsync -a /scratch/rootfs/ ./rootfs/rootfs
 fi


### PR DESCRIPTION
This is a follow-up PR to this discussion: https://github.com/concourse/builder-task/pull/25#issuecomment-492693392

Having seperate outputs for the oci tarball and rootfs improves when streaming to subsequent tasks/resources. A task/resource will most likely only consume one of the two outputs.

I opted to remove the `UNPACK_ROOTFS` and went with a fixed output named `rootfs`. I like it better as it removed one parameter from the task and the output needs to be defined anyway.