### PR TITLE
Build image with "--no-console" option

### DIFF
--- a/build
+++ b/build
@@ -129,7 +129,7 @@ if [ -e ./cache/whiteouts ]; then
 fi
 
 progress "building"
-img build -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $target_arg $build_args $CONTEXT
+img build --no-console -s /scratch/state -t $REPOSITORY:$tag_name -f $DOCKERFILE $target_arg $build_args $CONTEXT
 
 if [ -d ./cache ]; then
   progress "syncing state to cache"


### PR DESCRIPTION
`--no-console` switch for img disables console progress, which has benefits in CI mode:
- without `--no-console` there is a lot of log events in Concourse, which are replaying when opening pipeline, causing that it opens long time (it was something like 15s for my 5 minutes long building)
- instead, `--no-console` gives insight into build logs for specific layers

Signed-off-by: Rafal Witczak <rafal.witczak@relayr.io>

