### PR TITLE
Make image output optional if only rootfs is needed

### DIFF
--- a/build
+++ b/build
@@ -2,6 +2,11 @@
 
 set -e -u
 
+if ! [ -d ./image ] && ! [ -d ./rootfs ]; then
+  echo "at least one output 'image' or 'rootfs' must be specified"
+  exit 1
+fi
+
 function sanitize_cgroups() {
   mkdir -p /sys/fs/cgroup
   mountpoint -q /sys/fs/cgroup || \
@@ -149,6 +154,7 @@ if [ -d ./cache ]; then
   rsync -a /scratch/state/ ./cache/state
 fi
 
+mkdir -p image
 progress "saving image"
 img save -s /scratch/state -o image/image.tar $REPOSITORY:$tag_name
 

--- a/build
+++ b/build
@@ -2,11 +2,6 @@
 
 set -e -u
 
-if ! [ -d ./image ] && ! [ -d ./rootfs ]; then
-  echo "at least one output 'image' or 'rootfs' must be specified"
-  exit 1
-fi
-
 function sanitize_cgroups() {
   mkdir -p /sys/fs/cgroup
   mountpoint -q /sys/fs/cgroup || \
@@ -152,6 +147,11 @@ if [ -d ./cache ]; then
   done
 
   rsync -a /scratch/state/ ./cache/state
+fi
+
+if ! [ -d ./image ] && ! [ -d ./rootfs ]; then
+  echo "neither 'image' nor 'rootfs' are specified, finishing with no outputs"
+  exit 0
 fi
 
 mkdir -p image


### PR DESCRIPTION
Currently, if only `rootfs` is specified as an output, the task will fail with the following error message:

```
saving image
open image/image.tar: no such file or directory
```

This PR changes it so that the `image` directory is created if needed as well as ensuring at least one of the two outputs is specified. 