### PR TITLE
Fixes issue #33 by checking that the line is not empty.

### DIFF
--- a/build
+++ b/build
@@ -107,8 +107,10 @@ if [ -n "$BUILD_ARGS_FILE" ]; then
   expanded_build_args=()
   while IFS= read -r line || [ -n "$line" ];
   do
-    expanded_build_args+=("--build-arg")
-    expanded_build_args+=("${line}")
+    if [[ ! -z "$line" ]]; then
+      expanded_build_args+=("--build-arg")
+      expanded_build_args+=("${line}")
+    fi
   done < $BUILD_ARGS_FILE
   build_args="${expanded_build_args[@]}"
 else


### PR DESCRIPTION
Just like it says on the tin.

When a file containing key/value pairs is supplied to BUILD_ARGS_FILE, it must not contain empty lines, or the build will fail. This change should detect empty lines and omit them from the build_args var.